### PR TITLE
Handle prompting for report names when assigning records

### DIFF
--- a/app.js
+++ b/app.js
@@ -1916,11 +1916,58 @@ document.getElementById("exportCSVBtn").onclick = async function() {
     }
 
     const reportSelector = document.getElementById('assignReportSelector');
-    const selectedReportName = reportSelector.value;
-    
+    let selectedReportName = reportSelector.value;
+
     if (!selectedReportName) {
         showToast(t.toastSelectReport, 'warning');
         return;
+    }
+
+    if (selectedReportName === 'create_new_report') {
+        const existingReportNames = new Set(
+            data
+                .filter(d => d && d.hasOwnProperty('reportName'))
+                .map(d => d.reportName.toLowerCase())
+        );
+        Array.from(reportSelector.options)
+            .filter(option => option.value && option.value !== 'create_new_report')
+            .forEach(option => existingReportNames.add(option.value.toLowerCase()));
+
+        const existingOptionValues = new Set(
+            Array.from(reportSelector.options)
+                .filter(option => option.value && option.value !== 'create_new_report')
+                .map(option => option.value)
+        );
+
+        while (true) {
+            const inputName = prompt(t.promptReportName);
+            if (inputName === null) {
+                return;
+            }
+
+            const trimmedName = inputName.trim();
+            if (!trimmedName) {
+                continue;
+            }
+
+            let uniqueName = trimmedName;
+            let suffix = 2;
+            while (existingReportNames.has(uniqueName.toLowerCase())) {
+                uniqueName = `${trimmedName} (${suffix})`;
+                suffix += 1;
+            }
+
+            existingReportNames.add(uniqueName.toLowerCase());
+            selectedReportName = uniqueName;
+
+            if (!existingOptionValues.has(uniqueName)) {
+                reportSelector.add(new Option(uniqueName, uniqueName));
+                existingOptionValues.add(uniqueName);
+            }
+
+            reportSelector.value = selectedReportName;
+            break;
+        }
     }
 
     const newRecords = [];


### PR DESCRIPTION
## Summary
- prompt for a concrete report name when "Create new report" is chosen in the assignment modal
- reuse the entered name for the selector, ensuring uniqueness by appending a numeric suffix when necessary